### PR TITLE
fix failing tests for sparseMeasurements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,8 @@ Imports: S4Vectors, GenomicRanges, SummarizedExperiment (>= 0.2.0),
         OrganismDbi, GenomicFeatures, GenomeInfoDb, IRanges, ensembldb
 Suggests: testthat, roxygen2, bumphunter, hgu133plus2.db, Mus.musculus,
         TxDb.Mmusculus.UCSC.mm10.knownGene, rjson, knitr, rmarkdown, BiocStyle,
-        EnsDb.Mmusculus.v79, AnnotationHub, rtracklayer, utils, RMySQL, DBI
+        EnsDb.Mmusculus.v79, AnnotationHub, rtracklayer, utils, RMySQL, DBI,
+        GenomicRanges, matrixStats
 License: MIT + file LICENSE
 LazyData: true
 RoxygenNote: 7.1.1

--- a/R/EpivizMeasurement-class.R
+++ b/R/EpivizMeasurement-class.R
@@ -71,7 +71,7 @@ setMethod("show", signature(object="EpivizMeasurement"),
 
 setMethod(".appendEpivizMeasurement", "EpivizMeasurement",
           function(a, b) {
-            nms <- slotNames("SparseEpivizMeasurement")
+            nms <- slotNames("EpivizMeasurement")
             for (nm in nms) {
               cur_val <- slot(b, nm)
               if (is.list(slot(a, nm))) {

--- a/tests/testthat/test-data_fetch.R
+++ b/tests/testthat/test-data_fetch.R
@@ -1,5 +1,8 @@
 context("data fetch")
 
+source("helper-organismdb.R")
+source("helper-makeEset.R")
+
 test_that("block data fetch works", {
   gr <- GRanges(seqnames="chr1", ranges=IRanges::IRanges(start=1:10, width=1),
                  seqinfo=Seqinfo(seqnames="chr1",genome="hcb"))

--- a/tests/testthat/test-data_update.R
+++ b/tests/testthat/test-data_update.R
@@ -1,5 +1,7 @@
 context("update measurement")
 
+source("helper-makeEset.R")
+
 test_that("update block works", {
   gr1 <- GRanges(seqnames="chr1", ranges=IRanges::IRanges(start=1:10, width=1))
   gr2 <- GRanges(seqnames="chr12", ranges=IRanges::IRanges(start=1:1000,width=10))

--- a/tests/testthat/test-get_measurements.R
+++ b/tests/testthat/test-get_measurements.R
@@ -1,5 +1,8 @@
 context("get_measurements from data objects")
 
+source("helper-organismdb.R")
+source("helper-makeEset.R")
+
 test_that("get_measurements works for blocks", {
   gr <- GRanges(seqnames="chr1", ranges=IRanges::IRanges(start=1:10, width=1))
   ms_obj <- epivizrData::register(gr)
@@ -9,18 +12,19 @@ test_that("get_measurements works for blocks", {
 
   exp_ms <- list(
     list(
-      id = ms_id,
       name = ms_obj$.name,
       type = "range",
-      datasourceId = ms_id,
       datasourceGroup = ms_id,
-      datasourceName = ms_name,
       defaultChartType = "BlocksTrack",
       dataprovider = character(),
       annotation = NULL,
       minValue = as.numeric(NA),
       maxValue = as.numeric(NA),
-      metadata = NULL)
+      metadata = NULL,
+      id = ms_id,
+      datasourceId = ms_id,
+      datasourceName = ms_name
+      )
   )
   obs <- lapply(ms, as.list)
   expect_equal(obs, exp_ms)
@@ -37,18 +41,19 @@ test_that("get_measurements works for bp", {
     
   exp_ms <- lapply(1:2, function(i) {
       list(
-        id=paste0("score",i),
         name=paste0("score",i),
         type="feature",
-        datasourceId=ms_id,
         datasourceGroup=ms_id,
-        datasourceName=ms_name,
         defaultChartType="LineTrack",
         dataprovider=character(),
         annotation=NULL,
         minValue=rngs[1,i],
         maxValue=rngs[2,i],
-        metadata=NULL)
+        metadata=NULL,
+        id=paste0("score",i),
+        datasourceId=ms_id,
+        datasourceName=ms_name
+        )
   })
 
   obs_ms <- ms_obj$get_measurements()
@@ -66,18 +71,19 @@ test_that("get_measurements works for RangedSummarizedExperiment", {
   exp_ms <- lapply(c("A","B"), function(col) {
       i <- match(col,c("A","B"))
       list(
-        id=col,
         name=col,
         type="feature",
-        datasourceId=ms_id,
         datasourceGroup=ms_id,
-        datasourceName=ms_name,
         defaultChartType="ScatterPlot",
         dataprovider=character(),
         annotation=list(Treatment=as.character(colData(sset)[i,])),
         minValue=rngs[1,i],
         maxValue=rngs[2,i],
-        metadata=c("probeid"))
+        metadata=c("probeid"),
+        id=col,
+        datasourceId=ms_id,
+        datasourceName=ms_name
+        )
     })
 
   obs_ms <- ms_obj$get_measurements()
@@ -95,19 +101,21 @@ test_that("get_measurements works for ExpressionSet", {
   rngs <- sapply(1:2, function(i) range(pretty(range(exprs(eset)[,paste0("SAMP_",i)]))))
     
   exp_ms <- lapply(1:2, function(i) {
-    list(id=paste0("SAMP_",i),
+    list(
       name=paste0("SAMP_",i),
       type="feature",
-      datasourceId=ms_id,
       datasourceGroup=ms_id,
-      datasourceName=ms_name,
       defaultChartType="ScatterPlot",
       dataprovider=character(),
       annotation=list(a=as.character(pData(eset)[i,1]), 
                       b=as.character(pData(eset)[i,2])),
       minValue=rngs[1,i],
       maxValue=rngs[2,i],
-      metadata=c("PROBEID","SYMBOL"))
+      metadata=c("PROBEID","SYMBOL"),
+      id=paste0("SAMP_",i),
+      datasourceId=ms_id,
+      datasourceName=ms_name
+      )
   })
 
   obs_ms <- ms_obj$get_measurements()
@@ -121,19 +129,24 @@ test_that("get_measurements works for gene info gr", {
   ms_id <- ms_obj$get_id()
   ms_name <- ms_obj$get_source_name()
   
-  exp_ms <- list(list(id=ms_id,
+  exp_ms <- list(list(
                  name=ms_obj$.name,
                  type = "range",
-                 datasourceId = ms_id,
                  datasourceGroup = ms_id,
-                 datasourceName = ms_name,
                  defaultChartType = "GenesTrack",
                  dataprovider=character(),
                  annotation = NULL,
                  minValue = as.numeric(NA),
                  maxValue = as.numeric(NA),
-                 metadata = c("gene", "exon_starts", "exon_ends")))
+                 metadata = c("gene", "exon_starts", "exon_ends"),
+                 id=ms_id,
+                 datasourceId = ms_id,
+                 datasourceName = ms_name
+                )
+            )
   obs_ms <- ms_obj$get_measurements()
-  expect_equal(lapply(obs_ms, as.list), exp_ms)
+  obs_tst <- lapply(obs_ms, as.list)
+  obs_tst
+  expect_equal(obs_tst, exp_ms)
 })
 

--- a/tests/testthat/test-management.R
+++ b/tests/testthat/test-management.R
@@ -1,5 +1,8 @@
 context("measurement management")
 
+source("helper-organismdb.R")
+source("helper-makeEset.R")
+
 test_that("add measurement works without datasource_name", {
   server <- epivizrServer::createServer()
   mgr <- createMgr(server)
@@ -24,18 +27,20 @@ test_that("add measurement works without connection", {
   rngs <- unname(sapply(c("A","B"), function(col) range(pretty(range(assay(se,"counts2")[,col], na.rm=TRUE)))))
   exp_ms <- lapply(c("A","B"), function(col) {
     i <- match(col,c("A","B"))
-    list(id=col,
+    list(
          name=col,
          type="feature",
-         datasourceId=ms_id,
          datasourceGroup=ms_id,
-         datasourceName=ms_name,
          defaultChartType="ScatterPlot",
          dataprovider=character(),
          annotation=list(Treatment=as.character(colData(se)[i,])),
          minValue=rngs[1,i],
          maxValue=rngs[2,i],
-         metadata=c("probeid"))
+         metadata=c("probeid"),
+         id=col,
+         datasourceId=ms_id,
+         datasourceName=ms_name
+         )
   })
   
   ms_record <- mgr$.ms_list[[ms_id]]
@@ -54,7 +59,7 @@ test_that("get_measurements works without connection", {
   eset <- make_test_eset()
   
   server <- epivizrServer::createServer()
-  mgr <- createMgr(server)
+  mgr <- epivizrData::createMgr(server)
   
   msObj1 <- mgr$add_measurements(gr1, "dev1", send_request=FALSE); msId1=msObj1$get_id(); msName1=msObj1$get_source_name()
   msObj2 <- mgr$add_measurements(gr2, "dev2", send_request=FALSE); msId2=msObj2$get_id(); msName2=msObj2$get_source_name()
@@ -67,12 +72,10 @@ test_that("get_measurements works without connection", {
   res <- mgr$get_measurements()
     
   expMs <- list(
-      id=c(msId1, msId2, "score", paste0("SAMP_",1:2)),
+      
       name=c("dev1", "dev2", "score", paste0("SAMP_",1:2)),
       type=c(rep("range", 2), rep("feature",3)),
-      datasourceId=c(msId1, msId2, msId3, rep(msId4,2)),
       datasourceGroup=c(msId1, msId2, msId3, rep(msId4,2)),
-      datasourceName=c(msName1, msName2, msName3, rep(msName4, 2)),
       defaultChartType=c(rep("BlocksTrack", 2), "LineTrack", rep("ScatterPlot",2)),
       annotation=c(rep(list(NULL),3), 
                    lapply(1:2, function(i) 
@@ -80,7 +83,10 @@ test_that("get_measurements works without connection", {
                           b=as.character(pData(eset)[i,2])))),
       minValue=c(rep(NA,2), rngs3[1], rngs4[1,]),
       maxValue=c(rep(NA,2), rngs3[2], rngs4[2,]),
-      metadata=c(list(NULL), list(NULL), list(NULL), lapply(1:2,function(i) c("PROBEID","SYMBOL")))
+      metadata=c(list(NULL), list(NULL), list(NULL), lapply(1:2,function(i) c("PROBEID","SYMBOL"))),
+      id=c(msId1, msId2, "score", paste0("SAMP_",1:2)),
+      datasourceId=c(msId1, msId2, msId3, rep(msId4,2)),
+      datasourceName=c(msName1, msName2, msName3, rep(msName4, 2))
     )
     
   for (entry in names(expMs)) {


### PR DESCRIPTION
 i couldn't find a proper solution

1. Unless I source the helper-* files inside tests, They fail to run. I don't understand why, but tests started working again.
2. Since `EpivizMeasurement` extends `SparseEpivizMeasurement`, the order of slots changes and that needed change in the expectations. I would think it would be smart enough to check by names in the list :| 